### PR TITLE
Renames and docs to make golint clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Installation
   to do this, read [How to Write Go Code](https://golang.org/doc/code.html).
 - Download the package:
 ```sh
-go get github.com/saasbuilders/itembase
+go get gopkg.in/saasbuilders/itembase.v0
 ```
 
 Usage
@@ -32,7 +32,7 @@ High-level examples are shown here, see [the GoDoc][godoc] for the complete API.
 ### Config
 
 ```go
-import "github.com/saasbuilders/itembase"
+import "gopkg.in/saasbuilders/itembase.v0"
 
 config := itembase.Config{
 	ClientID:     "YOUR CLIENT ID",
@@ -210,4 +210,4 @@ the [Firebase API client].
 [Firebase API client]: https://github.com/ereyes01/firebase
 
 [godoc-badge]: http://img.shields.io/badge/godoc-reference-blue.svg?style=flat
-[godoc]: https://godoc.org/github.com/saasbuilders/itembase
+[godoc]: https://godoc.org/gopkg.in/saasbuilders/itembase.v0

--- a/README.md
+++ b/README.md
@@ -1,24 +1,33 @@
 Go Itembase
 ===========
 
-Helper library for invoking the Itembase REST API. Supports the following operations:
-- Read values from an Itembase path
-- Types and methods for the different [Itembase API endpoints](http://sandbox.api.itembase.io/swagger-ui/index.html)
+[![GoDoc][godoc-badge]][godoc]
 
-Based on the great work of [cosn](https://github.com/cosn), [JustinTulloss](https://github.com/JustinTulloss) and [ereyes01](https://github.com/ereyes01) on the Firebase REST API.
+A Go (golang) REST client library for [the Itembase API]. Supports all entities
+from the [Itembase API endpoints]:
 
-### Usage
+  - Buyers
+  - Products
+  - Store Profiles
+  - Transactions
 
-[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/saasbuilders/itembase)
+[the Itembase API]: http://business.itembase.com/connect
+[Itembase API endpoints]: http://sandbox.api.itembase.io/swagger-ui/index.html
 
-### Installation
+Installation
+------------
 
-- Setup your GOPATH and workspace. If you are new to Go and you're not sure how
-to do this, read [How to Write Go Code](https://golang.org/doc/code.html).
-- Dowload the package:
+- Setup your `GOPATH` and workspace. If you are new to Go and you're not sure how
+  to do this, read [How to Write Go Code](https://golang.org/doc/code.html).
+- Download the package:
 ```sh
 go get github.com/saasbuilders/itembase
 ```
+
+Usage
+-----
+
+High-level examples are shown here, see [the GoDoc][godoc] for the complete API.
 
 ### Config
 
@@ -65,7 +74,7 @@ pretty.Println(transactions)
 ### Querying Buyers
 
 ```go
-pretty.Println(storeRef.Buyers().Select("95d5c9ceeaad98706ce").Url())
+pretty.Println(storeRef.Buyers().Select("95d5c9ceeaad98706ce").URL())
 
 var buyers itembase.Buyers
 err := storeRef.Buyers().GetInto(&buyers)
@@ -79,7 +88,7 @@ pretty.Println(buyers)
 ### Querying the Store Profile
 
 ```go
-pretty.Println(storeRef.Profiles().Url())
+pretty.Println(storeRef.Profiles().URL())
 
 var profiles itembase.Profiles
 err := storeRef.Products().GetInto(&profiles)
@@ -93,8 +102,8 @@ pretty.Println(profiles)
 ### Querying Store Products
 
 ```go
-pretty.Println(storeRef.Products().Url())
-pretty.Println(storeRef.Products().Select("ee6f8dc930f5bcb671a0").Url())
+pretty.Println(storeRef.Products().URL())
+pretty.Println(storeRef.Products().Select("ee6f8dc930f5bcb671a0").URL())
 
 var products itembase.Products
 err := storeRef.Products().GetInto(&products)
@@ -109,9 +118,9 @@ pretty.Println(products)
 ### Querying Store Transactions
 
 ```go
-pretty.Println(storeRef.Transactions().Url())
-pretty.Println(storeRef.Transactions().Select("6ee2e2d9f7baea5132ab79b").Url())
-pretty.Println(storeRef.Transactions().CreatedAtFrom("2015-04-29T08:53:01.738+0200").Limit(2).Offset(6).Url())
+pretty.Println(storeRef.Transactions().URL())
+pretty.Println(storeRef.Transactions().Select("6ee2e2d9f7baea5132ab79b").URL())
+pretty.Println(storeRef.Transactions().CreatedAtFrom("2015-04-29T08:53:01.738+0200").Limit(2).Offset(6).URL())
 
 var transactions itembase.Transactions
 err := storeRef.Transactions().CreatedAtFrom("2015-05-07T09:53:01").Limit(3).Offset(6).GetInto(&transactions)
@@ -152,16 +161,14 @@ You will want to add your own token handlers to save tokens in your own datastor
 
 ```go
 func TokenHandler() itembase.ItembaseTokens {
-
 	return itembase.ItembaseTokens{
 		GetCachedToken, // How to retrieve a valid oauth token for a user
 		SaveToken,      // How to save a valid oauth token for a user
 		nil,            // What to do in case of expired tokens
 	}
-
 }
 
-func GetCachedToken(userId string) (token *oauth2.Token, err error) {
+func GetCachedToken(userID string) (token *oauth2.Token, err error) {
 
 	// retrieve oauth2.Token from your Database and assign it to &token
 
@@ -172,22 +179,35 @@ func GetCachedToken(userId string) (token *oauth2.Token, err error) {
 	return
 }
 
-func SaveToken(userId string, token *oauth2.Token) (err error) {
+func SaveToken(userID string, token *oauth2.Token) (err error) {
 
-	// save oauth2.Token to your Database for userId
+	// save oauth2.Token to your Database for userID
 
 	return
 }
 
-func TokenPermissions(authUrl string) (authcode string, err error) {
+func TokenPermissions(authURL string) (authcode string, err error) {
 	
-	// token expired, offline authurl provided
+	// token expired, offline authURL provided
 	// handle the token permission process, and return the new authcode
 
 	return
-
 }
 
 ```
 
 Off you go, now enjoy.
+
+Credits
+-------
+
+Originally based on the great work of [cosn], [JustinTulloss] and [ereyes01] on
+the [Firebase API client].
+
+[cosn]: https://github.com/cosn
+[JustinTulloss]: https://github.com/JustinTulloss
+[ereyes01]: https://github.com/ereyes01
+[Firebase API client]: https://github.com/ereyes01/firebase
+
+[godoc-badge]: http://img.shields.io/badge/godoc-reference-blue.svg?style=flat
+[godoc]: https://godoc.org/github.com/saasbuilders/itembase

--- a/api.go
+++ b/api.go
@@ -13,7 +13,7 @@ import (
 // httpClient is the HTTP client used to make calls to Itembase with the default API
 var httpClient = newTimeoutClient(connectTimeout, readWriteTimeout)
 
-// f is the internal implementation of the Itembase API client.
+// itembaseAPI is the internal implementation of the Itembase API client.
 type itembaseAPI struct{}
 
 var (
@@ -71,7 +71,7 @@ func (f *itembaseAPI) Call(method, path, auth string, body interface{}, params m
 
 	decoder := json.NewDecoder(response.Body)
 	if response.StatusCode >= 400 {
-		err := &ItembaseError{Code: response.StatusCode, Message: response.Status}
+		err := &Error{Code: response.StatusCode, Message: response.Status}
 		decoder.Decode(err)
 		return err
 	}

--- a/client.go
+++ b/client.go
@@ -5,18 +5,16 @@ import (
 	"encoding/json"
 )
 
-// ItembaseError is a Go representation of the error message sent back by itembase when a
+// Error is a Go representation of the error message sent back by itembase when a
 // request results in an error.
-type ItembaseError struct {
+type Error struct {
 	Message string `json:"message"`
 	Code    int    `json:"code"`
 }
 
-func (f *ItembaseError) Error() string {
+func (f *Error) Error() string {
 	return f.Message
 }
-
-// type ItembaseToken interface
 
 // This is the default implementation
 type client struct {
@@ -39,13 +37,13 @@ type client struct {
 	production bool
 
 	// api is the underlying client used to make calls.
-	api Api
+	api API
 
 	params  map[string]string
 	options Config
 }
 
-func New(options Config, api Api) Client {
+func New(options Config, api API) Client {
 	if api == nil {
 		api = new(itembaseAPI)
 	}
@@ -53,7 +51,7 @@ func New(options Config, api Api) Client {
 	return &client{options: options, production: options.Production, api: api}
 }
 
-func NewClient(root, auth string, api Api) Client {
+func NewClient(root, auth string, api API) Client {
 	if api == nil {
 		api = new(itembaseAPI)
 	}
@@ -61,7 +59,7 @@ func NewClient(root, auth string, api Api) Client {
 	return &client{url: root, root: root, auth: auth, api: api}
 }
 
-func (c *client) Url() string {
+func (c *client) URL() string {
 	return c.url
 }
 

--- a/client.go
+++ b/client.go
@@ -43,6 +43,13 @@ type client struct {
 	options Config
 }
 
+// New creates a new instance of the default itembase Client implementation.
+//
+// The options must be non-nil and must provide all OAuth2 credentials and
+// configuration for an application registered with the itembase API.
+//
+// TODO: always use the default API impl, NewClient allows dependency injection
+// needed for testing.
 func New(options Config, api API) Client {
 	if api == nil {
 		api = new(itembaseAPI)
@@ -51,6 +58,8 @@ func New(options Config, api API) Client {
 	return &client{options: options, production: options.Production, api: api}
 }
 
+// NewClient is an alternative Client constructor intended for testing or
+// advanced usage, where a custom API implementation can be injected.
 func NewClient(root, auth string, api API) Client {
 	if api == nil {
 		api = new(itembaseAPI)

--- a/declarations.go
+++ b/declarations.go
@@ -13,9 +13,9 @@ type Config struct {
 
 type Client interface {
 	// Returns the absolute URL path for the client
-	Url() string
+	URL() string
 
-	//Gets the value referenced by the client and unmarshals it into
+	// Gets the value referenced by the client and unmarshals it into
 	// the passed in destination.
 	GetInto(destination interface{}) error
 	Get() (destination interface{}, err error)
@@ -44,19 +44,19 @@ type Client interface {
 	Limit(limit uint) Client
 	Offset(offset uint) Client
 
-	SaveToken(userId string, token *oauth2.Token) (err error)
-	GetCachedToken(userId string) (token *oauth2.Token, err error)
-	GiveTokenPermissions(authUrl string) (authcode string, err error)
+	SaveToken(userID string, token *oauth2.Token) (err error)
+	GetCachedToken(userID string) (token *oauth2.Token, err error)
+	GiveTokenPermissions(authURL string) (authcode string, err error)
 }
 
-// Api is the internal interface for interacting with Itembase. The internal
+// API is the internal interface for interacting with Itembase. The internal
 // implementation of this interface is responsible for all HTTP operations that
 // communicate with Itembase.
 //
-// Users of this library can implement their own Api-conformant types for
-// testing purposes. To use your own test Api type, pass it in to the NewClient
+// Users of this library can implement their own API-conformant types for
+// testing purposes. To use your own test API type, pass it in to the NewClient
 // function.
-type Api interface {
+type API interface {
 	// Call is responsible for performing HTTP transactions such as GET, POST,
 	// PUT, PATCH, and DELETE. It is used to communicate with Itembase by all
 	// of the Client methods.
@@ -64,10 +64,11 @@ type Api interface {
 	// Arguments are as follows:
 	//  - `method`: The http method for this call
 	//  - `path`: The full itembase url to call
+	//	- `auth`: TODO
 	//  - `body`: Data to be marshalled to JSON (it's the responsibility of Call to do the marshalling and unmarshalling)
 	//  - `params`: Additional parameters to be passed to itembase
 	//  - `dest`: The object to save the unmarshalled response body to.
-	//    It's up to this method to unmarshal correctly, the default implemenation just uses `json.Unmarshal`
+	//    It's up to this method to unmarshal correctly, the default implementation just uses `json.Unmarshal`
 	Call(method, path, auth string, body interface{}, params map[string]string, dest interface{}) error
 }
 
@@ -77,6 +78,6 @@ type ItembaseTokens struct {
 	TokenPermissions TokenPermissions
 }
 
-type TokenSaver func(userId string, token *oauth2.Token) (err error)
-type TokenLoader func(userId string) (token *oauth2.Token, err error)
-type TokenPermissions func(authUrl string) (authcode string, err error)
+type TokenSaver func(userID string, token *oauth2.Token) (err error)
+type TokenLoader func(userID string) (token *oauth2.Token, err error)
+type TokenPermissions func(authURL string) (authcode string, err error)

--- a/declarations.go
+++ b/declarations.go
@@ -2,15 +2,35 @@ package itembase
 
 import "golang.org/x/oauth2"
 
+// A Config structure is used to configure an itembase Client instance.
 type Config struct {
-	ClientID     string
+	// ClientID is the OAuth2 application ID for a registered itembase app.
+	// See oauth2.Config.
+	ClientID string
+
+	// ClientSecret is the application's OAuth2 secret credential.
+	// See oauth2.Config.
 	ClientSecret string
-	Scopes       []string
+
+	// Scopes specify requested OAuth2 permissions, as defined by the itembase
+	// API. See oauth2.Config.
+	Scopes []string
+
+	// A TokenHandler provides handlers for lifecycle events of OAuth2 tokens.
 	TokenHandler ItembaseTokens
-	Production   bool
-	RedirectURL  string
+
+	// Production may be set to false to put a Client into sandbox mode.
+	Production bool
+
+	// RedirectURL is the URL to redirect users after requesting OAuth2
+	// permission grants from itembase. See oauth2.Config.
+	RedirectURL string
 }
 
+// A Client retrieves data from the itembase API. Use itembase.New to create an
+// instance of the default implementation.
+//
+// TODO: document each method
 type Client interface {
 	// Returns the absolute URL path for the client
 	URL() string
@@ -72,12 +92,23 @@ type API interface {
 	Call(method, path, auth string, body interface{}, params map[string]string, dest interface{}) error
 }
 
+// ItembaseTokens is a container struct holding handler functions for events in
+// an OAuth2 token's lifecycle.
 type ItembaseTokens struct {
 	TokenLoader      TokenLoader
 	TokenSaver       TokenSaver
 	TokenPermissions TokenPermissions
 }
 
+// A TokenSaver is called at points during OAuth2 authorization flow when an
+// application might wish to persist the given token to a data store or cache.
 type TokenSaver func(userID string, token *oauth2.Token) (err error)
+
+// A TokenLoader is called at points during OAuth2 authorization flow when an
+// application might wish to retrieve a persisted token from a data store.
 type TokenLoader func(userID string) (token *oauth2.Token, err error)
+
+// A TokenPermissions handler is called at points during OAuth2 authorization
+// flow when a grantor might have granted new permissions for an authorization,
+// such as new scopes.
 type TokenPermissions func(authURL string) (authcode string, err error)

--- a/itembasedeclarations.go
+++ b/itembasedeclarations.go
@@ -1,5 +1,12 @@
 package itembase
 
+// TODO: Some entities/models don't have the full set of fields from the API.
+// Some of the implementation detail structs (Contacts, Billing, pagination
+// containers, etc.) could perhaps be unexported.
+
+// A Profile represents a user profile entity from the itembase API.
+//
+// See http://sandbox.api.itembase.io/swagger-ui/
 type Profile struct {
 	Active    bool   `json:"active"`
 	AvatarURL string `json:"avatar_url"`
@@ -22,6 +29,7 @@ type Profile struct {
 	URL               string `json:"url"`
 }
 
+// An Address represents a mailing address model from the itembase API.
 type Address struct {
 	City    string `json:"city"`
 	Country string `json:"country"`
@@ -30,6 +38,8 @@ type Address struct {
 	Zip     string `json:"zip"`
 }
 
+// A Contact represents a container of contact information from itembase API
+// models.
 type Contact struct {
 	Addresses []Address `json:"addresses"`
 	Emails    []struct {
@@ -38,6 +48,9 @@ type Contact struct {
 	Phones []interface{} `json:"phones"`
 }
 
+// A Buyer represents a buyer entity from the itembase API.
+//
+// See http://sandbox.api.itembase.io/swagger-ui/
 type Buyer struct {
 	Active            bool    `json:"active"`
 	Contact           Contact `json:"contact"`
@@ -59,17 +72,21 @@ type Buyer struct {
 	URL               string  `json:"url"`
 }
 
+// A Category represents a product category model from the itembase API.
 type Category struct {
 	CategoryID string `json:"category_id"`
 	Language   string `json:"language"`
 	Value      string `json:"value"`
 }
 
+// A ProductDescription represents a product description model from the itembase
+// API, which may be in a specified language.
 type ProductDescription struct {
 	Language string `json:"language"`
 	Value    string `json:"value"`
 }
 
+// A Brand represents a product brand model from the itembase API.
 type Brand struct {
 	Name struct {
 		Language string `json:"language"`
@@ -77,6 +94,9 @@ type Brand struct {
 	} `json:"name"`
 }
 
+// A Product represents a product entity from the itembase API.
+//
+// See http://sandbox.api.itembase.io/swagger-ui/
 type Product struct {
 	Active     bool       `json:"active"`
 	Brand      Brand      `json:"brand"`
@@ -117,10 +137,15 @@ type Product struct {
 	Variants  []interface{} `json:"variants"`
 }
 
+// Billing represents a model from the itembase API containing the billing
+// address of a Transaction.
 type Billing struct {
 	Address Address `json:"address"`
 }
 
+// A Transaction represents a transaction entity from the itembase API.
+//
+// See http://sandbox.api.itembase.io/swagger-ui/
 type Transaction struct {
 	Billing           Billing   `json:"billing"`
 	Buyer             Buyer     `json:"buyer"`
@@ -144,30 +169,36 @@ type Transaction struct {
 	UpdatedAt     string  `json:"updated_at"`
 }
 
+// Transactions is a container for pagination of Transaction entities.
 type Transactions struct {
 	Transactions         []Transaction `json:"documents"`
 	NumDocumentsFound    float64       `json:"num_documents_found"`
 	NumDocumentsReturned float64       `json:"num_documents_returned"`
 }
 
+// Profiles is a container for pagination of Profile entities.
 type Profiles struct {
 	Profiles             []Profile `json:"documents"`
 	NumDocumentsFound    float64   `json:"num_documents_found"`
 	NumDocumentsReturned float64   `json:"num_documents_returned"`
 }
 
+// Products is a container for pagination of Product entities.
 type Products struct {
 	Products             []Product `json:"documents"`
 	NumDocumentsFound    float64   `json:"num_documents_found"`
 	NumDocumentsReturned float64   `json:"num_documents_returned"`
 }
 
+// Buyers is a container for pagination of Buyer entities.
 type Buyers struct {
 	Buyers               []Buyer `json:"documents"`
 	NumDocumentsFound    float64 `json:"num_documents_found"`
 	NumDocumentsReturned float64 `json:"num_documents_returned"`
 }
 
+// A User represents a user entity from the itembase API, such as returned from
+// the "me" endpoint.
 type User struct {
 	UUID              string `json:"uuid"`
 	Username          string `json:"username"`

--- a/oauth.go
+++ b/oauth.go
@@ -11,21 +11,16 @@ import (
 )
 
 func (c *client) newConf() *oauth2.Config {
-
 	var endpointURL string
 
 	if c.production {
-
 		endpointURL = "https://accounts.itembase.com/oauth/v2"
 		c.me = "https://users.itembase.com/v1/me"
 		c.root = "https://api.itembase.io/v1"
-
 	} else {
-
 		endpointURL = "http://sandbox.accounts.itembase.io/oauth/v2"
 		c.me = "http://sandbox.users.itembase.io/v1/me"
 		c.root = "http://sandbox.api.itembase.io/v1"
-
 	}
 
 	return &oauth2.Config{
@@ -38,34 +33,32 @@ func (c *client) newConf() *oauth2.Config {
 			TokenURL: endpointURL + "/token",
 		},
 	}
-
 }
 
-func (c *client) SaveToken(userId string, token *oauth2.Token) (err error) {
+func (c *client) SaveToken(userID string, token *oauth2.Token) (err error) {
 	if c.options.TokenHandler.TokenSaver != nil {
-		err = c.options.TokenHandler.TokenSaver(userId, token)
+		err = c.options.TokenHandler.TokenSaver(userID, token)
 	} else {
 		err = errors.New("No Token Store!")
 	}
 	return
 }
 
-func (c *client) GetCachedToken(userId string) (token *oauth2.Token, err error) {
+func (c *client) GetCachedToken(userID string) (token *oauth2.Token, err error) {
 	if c.options.TokenHandler.TokenLoader != nil {
-		token, err = c.options.TokenHandler.TokenLoader(userId)
+		token, err = c.options.TokenHandler.TokenLoader(userID)
 	} else {
 		err = errors.New("No Token Cache!")
 	}
 	return
 }
 
-func (c *client) GiveTokenPermissions(authUrl string) (authcode string, err error) {
-
+func (c *client) GiveTokenPermissions(authURL string) (authcode string, err error) {
 	// add logic for handing retrieving code for oauth exchange and matching state
 	// For example throw an error, and send email to user instead with this link
 
 	if c.options.TokenHandler.TokenPermissions != nil {
-		if authcode, err = c.options.TokenHandler.TokenPermissions(authUrl); err != nil {
+		if authcode, err = c.options.TokenHandler.TokenPermissions(authURL); err != nil {
 			log.Fatal(err)
 		}
 	} else {
@@ -79,16 +72,15 @@ func (c *client) GiveTokenPermissions(authUrl string) (authcode string, err erro
 	// an access token and initiate a Transport that is
 	// authorized and authenticated by the retrieved token.
 	return
-
 }
 
-// UserOauthClient returns an oauth2 client for a specific user
-func (c *client) UserOAuthClient(ctx context.Context, config *oauth2.Config, userId string) (client *http.Client, err error) {
+// UserOAuthClient returns an oauth2 client for a specific user
+func (c *client) UserOAuthClient(ctx context.Context, config *oauth2.Config, userID string) (client *http.Client, err error) {
 	var userToken *oauth2.Token
 
-	if userToken, err = c.GetCachedToken(userId); err != nil {
+	if userToken, err = c.GetCachedToken(userID); err != nil {
 		// if token for user is not cached then go through oauth2 flow
-		if userToken, err = c.newUserToken(ctx, config, userId); err != nil {
+		if userToken, err = c.newUserToken(ctx, config, userID); err != nil {
 			return
 		}
 	}
@@ -100,7 +92,7 @@ func (c *client) UserOAuthClient(ctx context.Context, config *oauth2.Config, use
 	return config.Client(ctx, userToken), err
 }
 
-func (c *client) newUserToken(ctx context.Context, config *oauth2.Config, userId string) (*oauth2.Token, error) {
+func (c *client) newUserToken(ctx context.Context, config *oauth2.Config, userID string) (*oauth2.Token, error) {
 	stateBytes := make([]byte, 32)
 	_, err := rand.Read(stateBytes)
 	if err != nil {
@@ -108,25 +100,23 @@ func (c *client) newUserToken(ctx context.Context, config *oauth2.Config, userId
 		return nil, err
 	}
 	state := fmt.Sprintf("%x", stateBytes)
-	authUrl := config.AuthCodeURL(state, oauth2.AccessTypeOffline)
+	authURL := config.AuthCodeURL(state, oauth2.AccessTypeOffline)
 
-	authcode, err := c.GiveTokenPermissions(authUrl)
+	authcode, err := c.GiveTokenPermissions(authURL)
 
 	token, err := config.Exchange(oauth2.NoContext, authcode)
 	if err != nil {
 		log.Fatalf("Exchange error: %v", err)
 		return nil, err
 	}
-	c.SaveToken(userId, token) // save token to datastore
+	c.SaveToken(userID, token) // save token to datastore
 
 	return token, nil
 }
 
-func (c *client) getUserToken(userId string) (Token *oauth2.Token) {
-
+func (c *client) getUserToken(userID string) (Token *oauth2.Token) {
 	config := c.newConf()
-
-	client, err := c.UserOAuthClient(oauth2.NoContext, config, userId)
+	client, err := c.UserOAuthClient(oauth2.NoContext, config, userID)
 
 	_, err = client.Get(c.me)
 	if err == nil {
@@ -139,7 +129,7 @@ func (c *client) getUserToken(userId string) (Token *oauth2.Token) {
 		log.Fatal("Exchange error: %v", err)
 	}
 
-	c.SaveToken(userId, Token)
+	c.SaveToken(userID, Token)
 
 	return
 }


### PR DESCRIPTION
I wanted my first pull request here to be tests, but since I don't have any sandbox access yet, it's a little difficult without being able to actually play with it :grin: (still doable though, the HTTP requests should be mocked anyway).

Anyhow, `golint` complains about identifiers for common acronyms and abbreviations like `Url`, `Api`, and `Id`. Renaming these is a breaking change, but we might as well get that out of the way while this library still has the umbilical cord attached…

It also nags you to document everything that is exported, so that is now done. `golint` now runs clean, with the one exception of `itembase.ItembaseTokens` "stuttering" (the same reason `itembase.ItembaseError` was renamed), but I want to try a redesign of the `ItembaseToken` approach anyway, so left that alone for the moment.

Speaking of breaking changes, [gopkg.in](http://gopkg.in) helps users avoid them. You can read all about it, but the gist is that it auto-magically redirects `go get` for a URL like http://gopkg.in/saasbuilders/itembase.v1 to GitHub and a branch named like `v1.2.1`. This way users don't unwittingly pull breaking changes into their builds, if they're not using some tight dependency control like Godeps (and if we properly follow Semantic Versioning by not making breaking changes without a major version number bump). I think this is a Good Thing™, so we should strongly encourage/advertise the gopkg.in URL for installs.

In the spirit of the SemVer convention for packages not ready to commit to stable releases, we are still making early breaking changes so should declare version zero (which is the gopkg.in default when there are no branches).
